### PR TITLE
Fix missing folder query scopes

### DIFF
--- a/app/Models/File.php
+++ b/app/Models/File.php
@@ -15,6 +15,22 @@ class File extends Model
         'is_folder' => 'boolean',
     ];
 
+    /**
+     * Scope a query to only include folders.
+     */
+    public function scopeWhereIsFolder($query, bool $isFolder = true)
+    {
+        return $query->where('is_folder', $isFolder);
+    }
+
+    /**
+     * Scope a query to only include files created by the given user.
+     */
+    public function scopeWhereCreatedBy($query, int $userId)
+    {
+        return $query->where('created_by', $userId);
+    }
+
     public function isOwnedBy($userId): bool
     {
         return $this->created_by == $userId;


### PR DESCRIPTION
## Summary
- add query scopes on File model for filtering folders and creators

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_684f902cb3ac8326a06f63623d37b2dd